### PR TITLE
fix get_max_q index + requirements needed when not in colab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-gym==0.21
+gym==0.25.2
 tqdm
 jupyter==1.0.0
 matplotlib
+numpy==1.26.4

--- a/src/Function-Approximation.ipynb
+++ b/src/Function-Approximation.ipynb
@@ -385,7 +385,7 @@
     "    \n",
     "    def get_max_q(self, state: State) -> float:\n",
     "        tiles = self.get_active_tiles(state)\n",
-    "        return np.max(self.best_action(tiles)[0])\n",
+    "        return np.max(self.best_action(tiles)[1])\n",
     "    \n",
     "    def get_q_value(self, state: State, action: Any) -> float:\n",
     "        tiles = self.get_active_tiles(state)\n",


### PR DESCRIPTION
We should use  ` return np.max(self.best_action(tiles)[1])` with index as 1 instead of 0 as we need the value.
Added numpy and gym versions which are needed when outside colab.